### PR TITLE
fix: Avoid module init timing issue cause missing localeParams

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -23,15 +23,6 @@ export type LanguageKey = keyof typeof languages;
 export type LanguageValue = (typeof languages)[LanguageKey];
 
 /**
- * Get locale parms for Astro's `getStaticPaths` function
- * @returns - The list of locale params
- * @see https://docs.astro.build/en/guides/routing/#dynamic-routes
- */
-export const localeParams = Object.keys(languages).map((language) => ({
-  params: { language },
-}));
-
-/**
  * Get the translation file based on the target language
  * If the target language is not found, it will fallback to English
  */

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,11 +1,9 @@
 ---
 import Base from '@/layouts/Base.astro';
 
-import { useTranslations, localeParams, type LanguageKey } from '@/i18n/i18n.ts';
+import { useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
 
 const t = useTranslations(Astro.currentLocale as LanguageKey);
-
-export const getStaticPaths = () => localeParams;
 ---
 
 <Base title={t('404-1')}>

--- a/src/pages/[language]/404.astro
+++ b/src/pages/[language]/404.astro
@@ -1,11 +1,15 @@
 ---
 import Base from '@/layouts/Base.astro';
 
-import { useTranslations, localeParams, type LanguageKey } from '@/i18n/i18n.ts';
+import { useTranslations, languages, type LanguageKey } from '@/i18n/i18n.ts';
 
 const t = useTranslations(Astro.currentLocale as LanguageKey);
 
-export const getStaticPaths = () => localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map((language) => ({
+    params: { language },
+  }));
+}
 ---
 
 <Base title={t('404-1')}>

--- a/src/pages/[language]/faq.astro
+++ b/src/pages/[language]/faq.astro
@@ -1,7 +1,7 @@
 ---
 import Base from '@/layouts/Base.astro';
 import Banner from '@/components/Banner.astro';
-import { localeParams, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
+import { languages, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
 import { getCollection, render } from 'astro:content';
 
 
@@ -10,7 +10,12 @@ const t = useTranslations(currentLocale as LanguageKey);
 
 const faqs = await getCollection('faq');
 const localeRelatedFaqs = faqs.filter(faq => faq.id.startsWith(currentLocale));
-export const getStaticPaths = () => localeParams;
+
+export function getStaticPaths() {
+  return Object.keys(languages).map((language) => ({
+    params: { language },
+  }));
+}
 ---
 
 <Base title={t('Navbar-4')}>

--- a/src/pages/[language]/index.astro
+++ b/src/pages/[language]/index.astro
@@ -1,14 +1,17 @@
 ---
 import Base from '@/layouts/Base.astro';
 import Banner from '@/components/Banner.astro';
-import { localeParams, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
+import { languages, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
 import { defaultLocale } from '@/i18n/i18n.ts';
 import { getRelativeLocaleUrl } from 'astro:i18n';
 
 const t = useTranslations(Astro.currentLocale as LanguageKey);
-export async function getStaticPaths() {
-  return localeParams;
-};
+
+export function getStaticPaths() {
+  return Object.keys(languages).map((language) => ({
+    params: { language },
+  }));
+}
 ---
 
 <Base title={t('Navbar-1')}>

--- a/src/pages/[language]/resume.astro
+++ b/src/pages/[language]/resume.astro
@@ -1,7 +1,7 @@
 ---
 import Base from '@/layouts/Base.astro';
 import { Icon } from 'astro-icon/components';
-import { localeParams, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
+import { languages, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
 import { getEntry } from 'astro:content';
 // Only use qrcode in dev env
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -15,7 +15,11 @@ const currentTime = new Date()
   .toLocaleDateString('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit' })
   .replace(/\//g, '-');
 
-export const getStaticPaths = () => localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map((language) => ({
+    params: { language },
+  }));
+}
 ---
 <Base title={t('Resume-1')}>
 <div style="padding-top: var(--navbar-height)" class='pb-16 flex flex-col gap-12'>

--- a/src/pages/[language]/work/index.astro
+++ b/src/pages/[language]/work/index.astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 import Base from '@/layouts/Base.astro';
 import Banner from '@/components/Banner.astro';
 
-import { localeParams, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
+import { languages, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
 
 const currentLocale = Astro.currentLocale as LanguageKey;
 const t = useTranslations(currentLocale);
@@ -16,7 +16,11 @@ const allProjectTechs = localeRelatedProjects.reduce<string[]>((acc, curr) => {
   return [...new Set([...acc, ...techs])]
 }, []).sort((a, b) => a.localeCompare(b))
 
-export const getStaticPaths = () => localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map((language) => ({
+    params: { language },
+  }));
+}
 ---
 
 <style>

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 import Base from '@/layouts/Base.astro';
 import Banner from '@/components/Banner.astro';
 
-import { localeParams, useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
+import { useTranslations, type LanguageKey } from '@/i18n/i18n.ts';
 
 const currentLocale = Astro.currentLocale as LanguageKey;
 const t = useTranslations(currentLocale);
@@ -15,8 +15,6 @@ const allProjectTechs = localeRelatedProjects.reduce<string[]>((acc, curr) => {
   const techs = curr.data?.tech || []
   return [...new Set([...acc, ...techs])]
 }, []).sort((a, b) => a.localeCompare(b))
-
-export const getStaticPaths = () => localeParams;
 ---
 
 <style>


### PR DESCRIPTION
Module initialization timing issue due to eager evaluation of top-level exports.

Will cause missing localeParams on dev mode.